### PR TITLE
Rust: Adding sqlx + web framework

### DIFF
--- a/rust-backend/.gitignore
+++ b/rust-backend/.gitignore
@@ -1,0 +1,3 @@
+/target
+/Cargo.lock
+Cargo.lock

--- a/rust-backend/Cargo.toml
+++ b/rust-backend/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "u_spoke"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sqlx = { version = "0.6", features = [ "runtime-tokio-native-tls" , "postgres" ] }
+tokio = { version = "1", features = ["full"] }

--- a/rust-backend/src/main.rs
+++ b/rust-backend/src/main.rs
@@ -1,0 +1,28 @@
+use sqlx::postgres::PgPoolOptions;
+// use sqlx::mysql::MySqlPoolOptions;
+// etc.
+
+// #[async_std::main]
+#[tokio::main]
+// or #[actix_web::main]
+async fn main() -> Result<(), sqlx::Error> {
+    // Create a connection pool
+    //  for MySQL, use MySqlPoolOptions::new()
+    //  for SQLite, use SqlitePoolOptions::new()
+    //  etc.
+    let pool = PgPoolOptions::new()
+        .max_connections(5)
+        .connect("postgres://postgres:password@127.0.0.1/postgres")
+        .await?;
+
+    // Make a simple query to return the given parameter (use a question mark `?` instead of `$1` for MySQL)
+    let row: (i64,) = sqlx::query_as("SELECT $1")
+        .bind(150_i64)
+        .fetch_one(&pool)
+        .await?;
+
+    assert_eq!(row.0, 150);
+    println!("It works! Debug Print of pool: {:#?}", pool);
+
+    Ok(())
+}


### PR DESCRIPTION
Initiated the Rust Backend and added the SQLX Crate along with a compatible Web Framework.

I decided to go with sqlx since it supports a variety of databases along with async.

https://crates.io/crates/sqlx

It seems we can choose between tokio or actix-web:

https://crates.io/crates/tokio
https://crates.io/crates/actix-web

https://kerkour.com/rust-web-framework-2022

For now I put in tokio by pure chance, it can be easily replaced with actix-web by placing:

```toml
# Actix-web:
sqlx = { version = "0.6", features = [ "runtime-actix-native-tls" , "postgres" ] }
actix-web = "4"
```

Inside Cargo.toml and using ```#[actix_web::main]``` instead of ```#[tokio::main]```.

I do not know whether to go with tokio or actix, so feel free to make the decision here @deavid and merge whenever!